### PR TITLE
Add operation retry for exceeded quota group OperationReadGroup

### DIFF
--- a/.changelog/4599.txt
+++ b/.changelog/4599.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+compute: fixed an issue where exceeding the operation rate limit would fail without retrying
+```

--- a/.changelog/4716.txt
+++ b/.changelog/4716.txt
@@ -1,0 +1,3 @@
+```release-note:none
+ 
+```

--- a/google/common_operation.go
+++ b/google/common_operation.go
@@ -111,7 +111,7 @@ func CommonRefreshFunc(w Waiter) resource.StateRefreshFunc {
 		op, err := w.QueryOp()
 		if err != nil {
 			// Retry 404 when getting operation (not resource state)
-			if isRetryableError(err, isNotFoundRetryableError("GET operation")) {
+			if isRetryableError(err, isNotFoundRetryableError("GET operation"), isOperationReadQuotaError) {
 				log.Printf("[DEBUG] Dismissed retryable error on GET operation %q: %s", w.OpName(), err)
 				return nil, "done: false", nil
 			}

--- a/google/error_retry_predicates.go
+++ b/google/error_retry_predicates.go
@@ -190,6 +190,17 @@ func isSqlOperationInProgressError(err error) (bool, string) {
 	return false, ""
 }
 
+// Retry if operation returns a 403 with the message for
+// exceeding the quota limit for 'OperationReadGroup'
+func isOperationReadQuotaError(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 403 && strings.Contains(gerr.Body, "Quota exceeded for quota group 'OperationReadGroup'") {
+			return true, "Waiting for quota to refresh"
+		}
+	}
+	return false, ""
+}
+
 // Retry if Monitoring operation returns a 429 with a specific message for
 // concurrent operations.
 func isMonitoringConcurrentEditError(err error) (bool, string) {

--- a/google/error_retry_predicates.go
+++ b/google/error_retry_predicates.go
@@ -194,7 +194,7 @@ func isSqlOperationInProgressError(err error) (bool, string) {
 // exceeding the quota limit for 'OperationReadGroup'
 func isOperationReadQuotaError(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok {
-		if gerr.Code == 403 && strings.Contains(gerr.Body, "Quota exceeded for quota group 'OperationReadGroup'") {
+		if gerr.Code == 403 && strings.Contains(gerr.Body, "Quota exceeded for quota group") {
 			return true, "Waiting for quota to refresh"
 		}
 	}

--- a/google/error_retry_predicates_test.go
+++ b/google/error_retry_predicates_test.go
@@ -1,0 +1,91 @@
+package google
+
+import (
+	"strconv"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+)
+
+func TestIsAppEngineRetryableError_operationInProgress(t *testing.T) {
+	err := googleapi.Error{
+		Code: 409,
+		Body: "Operation is already in progress",
+	}
+	isRetryable, _ := isAppEngineRetryableError(&err)
+	if !isRetryable {
+		t.Errorf("Error not detected as retryable")
+	}
+}
+
+func TestIsAppEngineRetryableError_p4saPropagation(t *testing.T) {
+	err := googleapi.Error{
+		Code: 404,
+		Body: "Unable to retrieve P4SA: [service-111111111111@gcp-gae-service.iam.gserviceaccount.com] from GAIA. Could be GAIA propagation delay or request from deleted apps.",
+	}
+	isRetryable, _ := isAppEngineRetryableError(&err)
+	if !isRetryable {
+		t.Errorf("Error not detected as retryable")
+	}
+}
+
+func TestIsAppEngineRetryableError_missingPage(t *testing.T) {
+	err := googleapi.Error{
+		Code: 404,
+		Body: "Missing page",
+	}
+	isRetryable, _ := isAppEngineRetryableError(&err)
+	if isRetryable {
+		t.Errorf("Error incorrectly detected as retryable")
+	}
+}
+
+func TestIsAppEngineRetryableError_serverError(t *testing.T) {
+	err := googleapi.Error{
+		Code: 500,
+		Body: "Unable to retrieve P4SA because of a bad thing happening",
+	}
+	isRetryable, _ := isAppEngineRetryableError(&err)
+	if isRetryable {
+		t.Errorf("Error incorrectly detected as retryable")
+	}
+}
+
+func TestIsCommonRetryableErrorCode_retryableErrorCode(t *testing.T) {
+	codes := []int{429, 500, 502, 503}
+	for _, code := range codes {
+		code := code
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			err := googleapi.Error{
+				Code: code,
+				Body: "some text describing error",
+			}
+			isRetryable, _ := isCommonRetryableErrorCode(&err)
+			if !isRetryable {
+				t.Errorf("Error not detected as retryable")
+			}
+		})
+	}
+}
+
+func TestIsCommonRetryableErrorCode_otherError(t *testing.T) {
+	err := googleapi.Error{
+		Code: 404,
+		Body: "Some unretryable issue",
+	}
+	isRetryable, _ := isCommonRetryableErrorCode(&err)
+	if isRetryable {
+		t.Errorf("Error incorrectly detected as retryable")
+	}
+}
+
+func TestIsOperationReadQuotaError_quotaExceeded(t *testing.T) {
+	err := googleapi.Error{
+		Code: 403,
+		Body: "Quota exceeded for quota group 'OperationReadGroup' and limit 'Operation read requests per 100 seconds' of service 'compute.googleapis.com' for consumer 'project_number:11111111'.",
+	}
+	isRetryable, _ := isOperationReadQuotaError(&err)
+	if !isRetryable {
+		t.Errorf("Error not detected as retryable")
+	}
+}


### PR DESCRIPTION
In CI, we're hitting errors like this:

```
level=error msg=Error: Error when reading or editing Target Pool
"ci-op-x5j99sbj-82914-2f74l-api": googleapi: Error 403: Quota exceeded
for quota group 'ReadGroup' and limit 'Read requests per 100 seconds' of
service 'compute.googleapis.com' for consumer
'project_number:711936183532'., rateLimitExceeded
```

This was fixed in v3.62.0, however v3.62.0 uses v2 of the terraform sdk. This
cherry-picks the change to the release-3.27.0 branch, and we can point the
installer to this fork.
